### PR TITLE
Help file visuals and FAQ

### DIFF
--- a/src/main/resources/views/ftl/includes/header.ftl
+++ b/src/main/resources/views/ftl/includes/header.ftl
@@ -9,7 +9,9 @@
   <ul id="menu" class="wrap">
     <li><a href="/index.html">Home</a></li>
     <li><a href="/features.html">Features</a></li>
+<!-- relegate the FAQ to the community section since its about Bitcoin, not Multibit
     <li><a href="/faq.html">FAQ</a></li>
+-->
     <li><a href="/community.html">Community</a></li>
     <li><a href="/blog.html">Blog</a></li>
     <li id="menuHelp"><a href="/help.html">Help</a></li>

--- a/src/main/resources/views/html/en/community.html
+++ b/src/main/resources/views/html/en/community.html
@@ -18,6 +18,7 @@
   <li><a href="http://howtobuybitcoins.info" target="_blank">How to buy bitcoins</a> -  in your country</li>
   <li><a href="https://bitcoin.it/wiki/FAQ" target="_blank">The Official FAQ</a> - a comprehensive review of Bitcoin</li>
   <li><a href="https://bitcoin.it/wiki/Myths" target="_blank">Debunking Myths</a> - go here if you're skeptical</li>
+  <li><a href="/faq.html" >I'm new to Bitcoin</a> - our own introduction to Bitcoin</li>
 </ul>
 
 <h2>Getting started for merchants</h2>

--- a/src/main/resources/views/html/en/help/v0.5/help_importingPrivateKeys.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_importingPrivateKeys.html
@@ -32,6 +32,6 @@
     MultiBit to sync the blockchain on its own.</p></li>
 </ol>
 
-<h2>Import private keys from the reference client</h2>
+<h3>Import private keys from the reference client</h3>
 <p>This is not currently supported. The easiest way to achieve it is to simply
   perform a standard Bitcoin transaction to the address provided by MultiBit.</p>

--- a/src/main/resources/views/html/en/help/v0.5/help_installing.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_installing.html
@@ -63,7 +63,8 @@ to add a password to a wallet and occurs deep within the platform-specific parts
 <pre>
 SIGSEGV (0xb) at pc=0x00007f97ec7d06a0, pid=588, tid=140289289742080
 </pre>
-<p>After some research <a href="https://github.com/jim618/multibit/issues/325" target="_blank">members of the MultiBit community</a> found that installing the Oracle Java 7 JVM fixed the problem.</p>
+<p>After some research <a href="https://github.com/jim618/multibit/issues/325" target="_blank">members of the MultiBit community</a> found that
+  installing the Oracle Java 7 JVM fixed the problem.</p>
 <h3>Related articles</h3>
 <p>Here are some related articles:</p>
 <ul>

--- a/src/main/resources/views/html/en/help/v0.5/help_lostOrForgottenPassword.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_lostOrForgottenPassword.html
@@ -1,7 +1,7 @@
 <h2>Lost or forgotten password</h2>
-<h2>What is the symptom ?</h2>
+<h3>What is the symptom ?</h3>
 <p>You're certain you typed in your password correctly, but MultiBit is not unlocking your wallet.</p>
-<h2>What can you do about it ?</h2>
+<h3>What can you do about it ?</h3>
 <p>MultiBit does not change passwords to encrypted wallets without your knowledge. There are several possibilities to explore:</p>
 <ol>
   <li>Make sure that you are using the most recent password you know. </li>
@@ -22,7 +22,7 @@
   <li>Does a trusted friend or relative have a copy?</li>
 </ul>
 
-<h2>I think they're in my password manager but there's hundreds to try...</h2>
+<h3>I think they're in my password manager but there's hundreds to try...</h3>
 <p>Some password managers provide a means to export their contents for backup purposes. From a security point of view this is a <strong>very risky</strong> thing to do. Assuming that you know the risks of exposing all your passwords and you are an advanced user of the command shell, here is what you can do to quickly work through a list of password candidates:</p>
 <ol>
   <li>Locate the key backup file the wallet directory (it has a .key extension) and copy it to a secure location on a safe machine (call it <code>target.key</code>).</li>
@@ -70,7 +70,7 @@ $ srm recovered.key
 <p><strong>Make sure you erase your terminal scrollback history</strong> to avoid leaving traces of console output containing passwords. In MacOS Terminal use Edit | Clear
   Scrollback. On Linux <code>echo -e '\0033\0143'</code> might do the trick. Windows, um, no idea.</p>
 
-<h2>Nope that didn't work...</h2>
+<h3>Nope that didn't work...</h3>
 
 <p>If you have really, truly lost or forgotten your password and you only have encrypted wallets, then it is likely that you have lost access to your bitcoin. There is <strong>absolutely no way</strong> that the MultiBit team can possibly recover them.</p>
 

--- a/src/main/resources/views/html/en/help/v0.5/help_lostOrForgottenPassword.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_lostOrForgottenPassword.html
@@ -8,6 +8,7 @@
   <li>Try combinations - change one character at a time to upper- or lowercase, swap characters, add a ! to the end and so on</li>
   <li>Examine the rolling wallet backups, and apply the same process.</li>
   <li>Examine the automatic private key exports - these are encrypted with your wallet password when they are generated</li>
+  <li>If the password uses non-English characters consider the effect of the local language miscoding them</li>
 </ol>
 
 <p>As a last resort go to a quiet room and relax. Think about where you might have put a copy of the password. Perhaps one of the following:</p>
@@ -21,5 +22,56 @@
   <li>Does a trusted friend or relative have a copy?</li>
 </ul>
 
-<p>If you have really, truly lost or forgotten your password and you only have encrypted wallets, then it is likely that you have lost access to your bitcoin. There is
-<strong>absolutely no way</strong> that the MultiBit team can possibly recover them.</p>
+<h2>I think they're in my password manager but there's hundreds to try...</h2>
+<p>Some password managers provide a means to export their contents for backup purposes. From a security point of view this is a <strong>very risky</strong> thing to do. Assuming that you know the risks of exposing all your passwords and you are an advanced user of the command shell, here is what you can do to quickly work through a list of password candidates:</p>
+<ol>
+  <li>Locate the key backup file the wallet directory (it has a .key extension) and copy it to a secure location on a safe machine (call it <code>target.key</code>).</li>
+  <li>Use your password manager's export function to copy your password as a CSV (comma separated values) file to the same location as the key file (call it <code>passwords.csv</code>).</li>
+  <li>Examine the CSV file to determine its layout (e.g. url,username,password,label etc) and note the column number of the password (it is 3 in the example).</li>
+  <li>Copy this Unix script (it might need modification for Windows) alongside the CSV file (call it <code>apply-guesses.sh</code>) and give it executable permissions with <code>chmod +x apply-guesses.sh</code>.</li>
+</ol>
+<pre>
+#!/bin/bash
+echo Usage: apply-guesses.sh [password CSV] [key file] 
+echo Password file: $1
+echo Key file: $2
+for password in $( awk -F , -v OFS=' ' '{print $3}' $1 ); do
+   echo ------
+   echo Attempting: $password...
+   openssl enc -d -p -aes-256-cbc -a -in $2 -out recovered.key -pass pass:$password
+   if [ $? -eq 0 ];
+     then 
+       echo "Success!";
+       break;
+     else 
+       echo "Failed";
+   fi
+   echo ------
+done
+</pre>  
+
+<p>You may need to adjust the <code>{print $3}</code> section on line 5 to reflect the password column (e.g. <code>{print $12}</code> if password is in position 12).</p>
+
+<p>Once ready execute the script as follows:</p>
+<pre>
+$ ./apply-guesses.sh passwords.csv target.key
+</pre>
+
+<p>The script will report each password as it tries it and will stop immediately upon successful decryption. If all goes well you can use the password with MultiBit to rescue your bitcoins.</p>
+
+<p><strong>Make sure you tidy up all your files after you have finished</strong>. Use the Unix "secure delete" command to remove each file in turn
+  using the 35-pass Gutmann algorithm if available:</p>
+<pre>
+$ srm passwords.csv
+$ srm target.key
+$ srm recovered.key
+</pre>
+
+<p><strong>Make sure you erase your terminal scrollback history</strong> to avoid leaving traces of console output containing passwords. In MacOS Terminal use Edit | Clear
+  Scrollback. On Linux <code>echo -e '\0033\0143'</code> might do the trick. Windows, um, no idea.</p>
+
+<h2>Nope that didn't work...</h2>
+
+<p>If you have really, truly lost or forgotten your password and you only have encrypted wallets, then it is likely that you have lost access to your bitcoin. There is <strong>absolutely no way</strong> that the MultiBit team can possibly recover them.</p>
+
+<p>You should keep the encrypted files safe just in case inspiration strikes. Never delete a private key, just archive it safely.</p>

--- a/src/main/resources/views/html/en/help/v0.5/help_movingAWallet.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_movingAWallet.html
@@ -12,7 +12,7 @@
   <li>Close the original wallet to avoid confusion. Closing will not delete the wallet.</li>
 </ol>
 
-<h2>Moving a wallet between MultiBit and Blockchain.info</h2>
+<h3>Moving a wallet between MultiBit and Blockchain.info</h3>
 <p>Normally it is best to leave your Bitcoin wallet in the application that made it.</p>
 <p>Sometimes however you need to move your wallet from one application to another. This may be because the Blockchain.info site is down for maintenance or you would prefer to use another Bitcoin wallet rather than MultiBit. This help file describes how to move a MultiBit wallet to the blockchain.info site and vice versa.</p>
 

--- a/src/main/resources/views/html/en/help/v0.5/help_runFromUSBDrive.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_runFromUSBDrive.html
@@ -45,7 +45,7 @@
   MultiBit.app. Then go to where your wallets are stored and copy the files multibit.properties and
   multibit.spvchain onto your USB drive into the same directory. You can then double click the MultiBit.app
   on your USB drive to run MultiBit</p>
-<h2>Notes and Limitations</h2>
+<h3>Notes and Limitations</h3>
 <ol>
   <li>The path of the wallets in the configuration file contains the USB drive letter which may change according to how
     many other drives you have plugged in. In this case the wallets other than multibit.wallet will not be found when

--- a/src/main/resources/views/html/en/help/v0.5/help_support_insufficientFundsOnSend.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_support_insufficientFundsOnSend.html
@@ -1,7 +1,7 @@
 <h2>I get the error 'Insufficient funds' when I try to send bitcoin</h2>
-<h2>What is the symptom ?</h2>
+<h3>What is the symptom ?</h3>
 <p>You try to send some bitcoin but when you press the 'Send' button you get the error 'Insufficient funds' appearing in a dialog box.</p>
 
-<h2>What does 'Insufficient funds' mean ?</h2>
+<h3>What does 'Insufficient funds' mean ?</h3>
 <p>In your wallet you can normally only spend bitcoin that have confirmed. This is shown graphically in the '<img width="16" height="16" title="Transactions" alt="Transactions" src="/images/en/v0_5/transactions.png"/>&nbsp;Transactions' tab when the status icon is no longer empty. If you have unconfirmed transactions you get an 'Available to spend' balance in the MultiBit header. This shows the amount in your wallet that is available to spend. See <a href="help_availableToSpend.html">What does 'available to spend mean ?'</a> for more details.</p>
 <p>Also, you need to take into account the <b>fee</b> that is added to your transaction. The fee varies according to the size of the transaction but is typically 0.0001 BTC. For instance, if you have 10 BTC in your wallet and the fee is 0.0001 BTC then you can only spend a maximum of 10 - 0.0001 = 9.9999 BTC.</p>

--- a/src/main/resources/views/html/en/help/v0.5/help_support_missingWallets.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_support_missingWallets.html
@@ -1,8 +1,8 @@
 <h2>I opened MultiBit and my wallets were missing</h2>
-<h2>What are the symptoms ?</h2>
+<h3>What are the symptoms ?</h3>
 <p>You open MultiBit and instead of seeing your wallet(s) in the Wallet list, you don't see anything. The wallet(s) have probably just been closed.</p>
 
-<h2>What can you do when this happens ?</h2>
+<h3>What can you do when this happens ?</h3>
 
 <p>Relax - you are very likely to still have your wallet(s) on your disk. Do the following:</p>
 <ol>

--- a/src/main/resources/views/html/en/help/v0.5/help_support_sentBitcoinFromMultibitButTheyAreStuck.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_support_sentBitcoinFromMultibitButTheyAreStuck.html
@@ -40,7 +40,7 @@
   <img width="16" height="16" title="Reset" alt="Reset" src="/images/en/v0_5/resetTransactions.png"/>&nbsp;Reset Blockchain and Transactions'.
 </p>
 
-<h2>Related articles</h2>
+<h3>Related articles</h3>
 <p>Here are some related articles:</p>
 <ul>
   <li><a href="help_sendingBitcoin.html">Sending bitcoin</a></li>

--- a/src/main/resources/views/html/en/help/v0.5/help_support_sentBitcoinToMultibitButTheyNeverArrived.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_support_sentBitcoinToMultibitButTheyNeverArrived.html
@@ -21,7 +21,7 @@
 <h3>I'm running an old version of MultiBit (before 0.5.16)</h3>
 <p>Earlier versions of MultiBit did not show transactions that had inputs that were not confirmed. As this caused confusion this has been changed in version 0.5.16 so that these transactions are shown (unconfirmed). If you have an old version of MultiBit download the latest copy and install it. You will need to do a '<img width="16" height="16" title="Reset" alt="Reset" src="/images/en/v0_5/resetTransactions.png"/>&nbsp;Reset blockchain and transactions' so that MultiBit can resync to see any transactions like this.</p>
 
-<h2>Related articles</h2>
+<h3>Related articles</h3>
 <p>Here are some related articles</p>
 <ul>
   <li><a href="help_receivingBitcoin.html">Receiving bitcoin</a></li>

--- a/src/main/resources/views/html/en/help/v0.5/help_troubleshooting.html
+++ b/src/main/resources/views/html/en/help/v0.5/help_troubleshooting.html
@@ -6,7 +6,7 @@
 <p>For a more detailed description of what has happened with MultiBit there is a log file to look at. This is stored in
   the 'log' directory in your user data directory and is called 'multibit.log'. Use a simple text viewer like Notepad or TextEdit to read it.</p>
 
-<h2>Where MultiBit stores your data</h2>
+<h3>Where MultiBit stores your data</h3>
 <p>MultiBit stores user specific data such as logs and the default multibit.wallet in a "user data directory". This directory can be worked out as follows:</p>
 <ol>
   <li>Check the the very top of the "Messages" tab for a message like "The user data directory is '/Users/jim/Library/Application Support/MultiBit'"</li>
@@ -16,7 +16,7 @@
   <li>If none of these reveal the answer, use the technical approach given below.</li>
 </ol>
 
-<h2>Technical approach</h2>
+<h3>Technical approach</h3>
 <p>This section is for technical users proficient with accessing environment variables. These are enclosed in "[]" such that [APPDATA] references the APPDATA environment variable.</p>
 <h3>Windows</h3>
 <p>Try one of the following locations, remembering that you may need to enable hidden directories</p>
@@ -37,7 +37,7 @@
   <li><code>[user.home]/MultiBit</code>. Ubuntu/Debian: <code>/home/jim/MultiBit</code>
 </ul>
 
-<h2>Related articles</h2>
+<h3>Related articles</h3>
 <p>Here are some related articles</p>
 <ul>
   <li><a href="help_fileDescriptions.html">File descriptions</a></li>


### PR DESCRIPTION
Minor format change to help files - have just one h2 sized header (for consistency).

Move FAQ section (which introduces reader to Bitcoin) to the list of introductions to Bitcoin in Communiy page, to focus reader on Multibit.
